### PR TITLE
Add MyVibe to Static hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ List of all static site hosting platform <sup>[1](#status)</sup>
 | ---------------------------------------------------------------- | -------------------------------------------------------- | ------ | --------- | ----------------- | ------ | ------ |
 | [Github Pages](https://pages.github.com)                         | -                                                        | No     | Yes       |                   | Static | No     |
 | [Rollout](https://rollout.run)                                   | -                                                        | No     | Yes       |                   | Static | No     |
+| [MyVibe](https://myvibe.so)                                      | -                                                        | No     | Yes       |                   | Static | No     |
 | [tiiny.host](https://tiiny.host)                                 | [Tiny](https://tiiny.host) (5 \$/m)                      | No     | No        |                   | Static | No     |
 | [DigitalOcean Platform][do-ref]                                  | [Pay-as-you-Go][do-ref] (5 \$/m)                         | 60-day | Yes       |                   | Static | No     |
 | [qodi](https://qoddi.com)                                        | [XS](https://qoddi.com/pricing) (6 \$/m)                 | No     | 3 apps    |                   | Static | No     |


### PR DESCRIPTION
## Summary
- Adds MyVibe (https://myvibe.so) to the Static hosting table
- MyVibe provides instant publishing for AI-generated web apps

## Why MyVibe fits this list
MyVibe offers free static hosting with auto-detection for multiple frameworks (Vite, Next.js, Astro, Nuxt), fitting well with other hosting services in this list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)