### PR TITLE
Add FreeKit — free instant HTML hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ List of all static site hosting platform <sup>[1](#status)</sup>
 
 | Name                                                             | Minimal plan                                             | Trial  | Free      | Open Source       | Type   | Lambda |
 | ---------------------------------------------------------------- | -------------------------------------------------------- | ------ | --------- | ----------------- | ------ | ------ |
+| [FreeKit](https://freekit.dev)                                   | -                                                        | No     | Yes       |                   | Static | No     |
 | [Github Pages](https://pages.github.com)                         | -                                                        | No     | Yes       |                   | Static | No     |
 | [Rollout](https://rollout.run)                                   | -                                                        | No     | Yes       |                   | Static | No     |
 | [MyVibe](https://myvibe.so)                                      | -                                                        | No     | Yes       |                   | Static | No     |

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ List of all static site hosting platform <sup>[1](#status)</sup>
 | ---------------------------------------------------------------- | -------------------------------------------------------- | ------ | --------- | ----------------- | ------ | ------ |
 | [FreeKit](https://freekit.dev)                                   | -                                                        | No     | Yes       |                   | Static | No     |
 | [Github Pages](https://pages.github.com)                         | -                                                        | No     | Yes       |                   | Static | No     |
-| [Rollout](https://rollout.run)                                   | -                                                        | No     | Yes       |                   | Static | No     |
 | [MyVibe](https://myvibe.so)                                      | -                                                        | No     | Yes       |                   | Static | No     |
+| [Rollout](https://rollout.run)                                   | -                                                        | No     | Yes       |                   | Static | No     |
 | [tiiny.host](https://tiiny.host)                                 | [Tiny](https://tiiny.host) (5 \$/m)                      | No     | No        |                   | Static | No     |
 | [DigitalOcean Platform][do-ref]                                  | [Pay-as-you-Go][do-ref] (5 \$/m)                         | 60-day | Yes       |                   | Static | No     |
 | [qodi](https://qoddi.com)                                        | [XS](https://qoddi.com/pricing) (6 \$/m)                 | No     | 3 apps    |                   | Static | No     |


### PR DESCRIPTION
## What

Adds [FreeKit](https://freekit.dev) to the **Static** hosting section, placed alphabetically before Github Pages.

## About FreeKit

FreeKit is a free instant HTML hosting API backed by Azure Blob Storage. Upload HTML content via REST API and get a hosted URL instantly. No API key required, free forever.

- Website: https://freekit.dev
- API docs: https://freekit.dev/docs
- Free tier: Yes (no paid plans)
- Type: Static