### PR TITLE
docs(vps): add megahost.kz

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ List of all Virtual Private Server <sup>[1](#status)</sup>
 | [alwaysdata](https://www.alwaysdata.com/en)   | [Plus](https://www.alwaysdata.com/en/offers) (5 €/m)                        | No                 | Yes                   |                  |
 | [CloudTTK](https://cloud.ttk.ru)              | [VMWare](https://cloud.ttk.ru/infrastructure/#uc-tab2) (6 \$/m)             | No                 | No                    |                  |
 | [AlfaHost](https://alfahost.io)               | [Pricing](https://alfahost.io/?tab=vps) (6 \$/m)                            | No                 | No                    |                  |
+| [Megahost](https://megahost.kz/vps)           | [SSD-mini](https://megahost.kz/vps) (6.5 \$/m)                              | No                 | No                    |                  |
 | [Adaptable](https://adaptable.io)             | Hobby (7 \$/m)                                                              | No                 | Public-repos only     |                  |
 | [rdp.monster][rdp-monster-ref]                | [Basic](https://rdp.monster) (9 €/m)                                        | No                 | No                    |                  |
 | [CloudSigma](https://cloudsigma.com)          | [Small-2](https://cloudsigma.com/pricing) (12 \$/m)                         | 7-day              | No                    |                  |


### PR DESCRIPTION
## Summary

- Added [Megahost](https://megahost.kz/vps) to the VPS list

## Metadata

| Name | Minimal plan | Trial | Free | Open Source |
| --- | --- | --- | --- | --- |
| [Megahost](https://megahost.kz/vps) | [SSD-mini](https://megahost.kz/vps) (6.5 \$/m) | No | No | |

## Notes

- Price: 3,000 ₸/month (SSD-mini) converted to USD at ~6.5 $/m
- No trial, no free plan
- Inserted between AlfaHost (6 $/m) and Adaptable (7 $/m) sorted by price