### PR TITLE
docs(vps): add cloudzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ List of all Virtual Private Server <sup>[1](#status)</sup>
 | [AlfaHost](https://alfahost.io)               | [Pricing](https://alfahost.io/?tab=vps) (6 \$/m)                            | No                 | No                    |                  |
 | [Megahost](https://megahost.kz/vps)           | [SSD-mini](https://megahost.kz/vps) (6.5 \$/m)                              | No                 | No                    |                  |
 | [Adaptable](https://adaptable.io)             | Hobby (7 \$/m)                                                              | No                 | Public-repos only     |                  |
+| [Cloudzy](https://cloudzy.com)                | [Basic](https://cloudzy.com/pricing/) (7.48 \$/m)                           | 14-day             | No                    |                  |
 | [rdp.monster][rdp-monster-ref]                | [Basic](https://rdp.monster) (9 €/m)                                        | No                 | No                    |                  |
 | [CloudSigma](https://cloudsigma.com)          | [Small-2](https://cloudsigma.com/pricing) (12 \$/m)                         | 7-day              | No                    |                  |
 | [Hostinger](https://hostinger.com)            | [KVM 1](https://hostinger.com/vps-hosting) (14 \$/m)                        | No                 | No                    |                  |


### PR DESCRIPTION
## Summary

Added Cloudzy as a new VPS hosting provider to the awesome-hosting list.

## Provider Details

| Name                       | Minimal plan          | Trial  | Free | Open Source |
| -------------------------- | --------------------- | ------ | ---- | ----------- |
| [Cloudzy](https://cloudzy.com) | [Basic](https://cloudzy.com/pricing/) (7.48 $/m) | 14-day | No   |             |

Cloudzy offers affordable cloud VPS starting at $7.48/month with a 14-day money-back guarantee. Entry is properly positioned in the VPS list sorted by price.

## Test plan

- [x] Entry is correctly positioned between Adaptable ($7/m) and rdp.monster ($9€/m)
- [x] Pricing reflects monthly plan (not promotional pricing)
- [x] Trial information is accurate (14-day money-back guarantee)
- [x] Formatting passes prettier validation
- [x] Entry follows the same structure as other providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)