### PR TITLE
docs(vps): add serverspace.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ List of all Virtual Private Server <sup>[1](#status)</sup>
 | [Hetzner](https://www.hetzner.com) ⛔️         | [See plans](https://www.hetzner.com/cloud) (3.99 €/m)                       | No                 | No                    |                  |
 | [RuVPS](https://ruvps.net)                    | [VPS-1](https://ruvps.net/en/vps) (4.5 $/m)                                 | No                 | No                    |                  |
 | [Contabo](https://contabo.com/en/vps)         | [See pricing](https://contabo.com/en/pricing) (4.50 €/m)                    | No                 | No                    |                  |
+| [Serverspace](https://serverspace.io)         | [vStack](https://serverspace.io/pricing) (4.63 €/m)                         | No                 | No                    |                  |
 | [SSD Nodes](https://www.ssdnodes.com) ⛔️      | [KVM / Small](https://www.ssdnodes.com/pricing) (4.99 \$/m)                 | 14-day refund only | No                    |                  |
 | [Linode][linode-ref] ✅                       | [Nanode 1GB][linode-ref] (5 \$/m)                                           | 60-day             | $100 credit           |                  |
 | [Rackgenius](https://rackgenius.com)          | [2GB Value KVM VPS](https://rackgenius.com/vps) (5 \$/m)                    | No                 | No                    |                  |


### PR DESCRIPTION
Adds Serverspace to the VPS providers list.

| Name | Minimal plan | Trial | Free | Open Source |
| --- | --- | --- | --- | --- |
| [Serverspace](https://serverspace.io) | [vStack](https://serverspace.io/pricing) (4.63 €/m) | No | No | |

Verified from official pricing and FAQ:
- https://serverspace.io/pricing
- https://serverspace.io/conditions/faq