### PR TITLE
Add DeployBase to Containers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,12 @@ List of all Container-as-a-Service platform (likely Docker and Podman containers
 | [DigitalOcean Platform][do-ref]                                       | [Pay-as-you-Go][do-ref] (5 \$/m)                                               | 60-day | Yes                    |             |
 | [Rivet](https://rivet.dev)                                            | [Hobby](https://rivet.dev/pricing) (5 \$/m)                                    | No     | Yes                    |             |
 | [Fly.io Machines](https://fly.io/docs/machines)                       | [Pay-as-you-Go](https://fly.io/pricing)                                        | No     | No                     |             |
+| [DeployBase](https://deploybase.io) | [See plans](https://deploybase.io/pricing) (5 \$/m) | No | No |  |
 
 ### Lambda
 
 List of all Lambda(Serverless)-as-a-Service platform <sup>[1](#status)</sup>
+
 
 | Name                                                                 | Minimal plan                                                                                         | Trial  | Free                   | Open Source |
 | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------ | ---------------------- | ----------- |

--- a/README.md
+++ b/README.md
@@ -105,13 +105,12 @@ List of all Container-as-a-Service platform (likely Docker and Podman containers
 | [Cloudflare Containers](https://developers.cloudflare.com/containers) | [Pay-as-you-Go](https://developers.cloudflare.com/containers/pricing) (5 \$/m) | No     | No                     |             |
 | [DigitalOcean Platform][do-ref]                                       | [Pay-as-you-Go][do-ref] (5 \$/m)                                               | 60-day | Yes                    |             |
 | [Rivet](https://rivet.dev)                                            | [Hobby](https://rivet.dev/pricing) (5 \$/m)                                    | No     | Yes                    |             |
+| [DeployBase](https://deploybase.io)                                   | [Starter](https://deploybase.io/pricing) (6 \$/m)                              | No     | No                     |             |
 | [Fly.io Machines](https://fly.io/docs/machines)                       | [Pay-as-you-Go](https://fly.io/pricing)                                        | No     | No                     |             |
-| [DeployBase](https://deploybase.io) | [See plans](https://deploybase.io/pricing) (5 \$/m) | No | No |  |
 
 ### Lambda
 
 List of all Lambda(Serverless)-as-a-Service platform <sup>[1](#status)</sup>
-
 
 | Name                                                                 | Minimal plan                                                                                         | Trial  | Free                   | Open Source |
 | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------ | ---------------------- | ----------- |


### PR DESCRIPTION
DeployBase (https://deploybase.io) is a managed cloud hosting platform that simplifies application deployment. Launch WordPress, Laravel, Node.js and other web applications in seconds with automated SSL provisioning, scheduled backups, and seamless scaling. Plans start at $5/month.