### PR TITLE
docs(vps): add `scalahosting.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ List of all Virtual Private Server <sup>[1](#status)</sup>
 | [Hostinger](https://hostinger.com)            | [KVM 1](https://hostinger.com/vps-hosting) (14 \$/m)                          | No                 | No                    |                  |
 | [DarkVPS](https://darkvps.pro)                | [See plans](https://darkvps.pro/#pricing) (€ 15/m)                            | No                 | No                    |                  |
 | [Hosting](https://hosting.com)                | [VPS XS](https://hosting.com/hosting/vps-hosting/unmanaged/linux) (20 \$/m)   | No                 | No                    |                  |
+| [ScalaHosting](https://www.scalahosting.com)  | [Build #1](https://www.scalahosting.com/linux-vps-hosting.html) (24.95 \$/m)  | No                 | No                    |                  |
 | [fly.io](https://fly.io)                      | [Launch](https://fly.io/plans) (29 \$/m)                                      | No                 | Yes (3 shared-cpu VM) |                  |
 
 ---


### PR DESCRIPTION
## Entry

| Name                                           | Minimal plan                                                                 | Trial | Free | Open Source |
| ---------------------------------------------- | ---------------------------------------------------------------------------- | ----- | ---- | ----------- |
| [ScalaHosting](https://www.scalahosting.com)   | [Build #1](https://www.scalahosting.com/linux-vps-hosting.html) (24.95 \$/m) | No    | No   |             |

## Validation

- Checked `README.md` for existing `ScalaHosting` / `scalahosting` entries before adding.
- Used ScalaHosting's official Linux VPS pricing page.
- Used the non-discount renewal/monthly price for Build #1 (`24.95 \$/m`), not the temporary intro offer.
- Confirmed adjacent VPS ordering: `Hosting` at `20 \$/m`, ScalaHosting at `24.95 \$/m`, `fly.io` at `29 \$/m`.
- Ran `npx prettier -c README.md --write`.
