### PR TITLE
Add ApexWeave to BaaS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ List of all Backend-as-a-Service platform <sup>[1](#status)</sup>
 | ------------------------------------------------------------------------ | ----------------------------------------------------- | ----------- | ----------------- | ----------- | ------- | ------ |
 | [Cloudflare Workers](https://workers.cloudflare.com/product/workers)     | [Pro](https://workers.cloudflare.com/plans) (5 \$/m)  | No          | Yes               |             | Lambda  | Yes    |
 | [DigitalOcean Platform][do-ref]                                          | [Pay-as-you-Go][do-ref] (5 \$/m)                      | $200 credit | Yes               |             | Static  | No     |
+| [ApexWeave](https://apexweave.com)                                       | [Plans](https://apexweave.com/compare) (5 \$/m)       | Yes         | Yes               |             | Dynamic | No     |
 | [Heroku](https://www.heroku.com)                                         | [Eco](https://www.heroku.com/pricing) (5 \$/m)        | No          | No                |             | Dynamic | No     |
 | [PocketHost](https://pockethost.io)                                      | [Starter](https://pockethost.io/pricing) (5 \$/m)     | No          | Yes               |             | Dynamic |        |
-| [ApexWeave](https://apexweave.com)                                       | [Plans](https://apexweave.com/compare) (4 \$/m)       | Yes         | Yes               |             | Dynamic | No     |
 | [litegix](https://litegix.com) ⚠️                                        | [Hobby](https://litegix.com/pricing) (5 \$/m)         | No          | Yes               |             | Dynamic | -      |
 | [Sevalla](https://sevalla.com)                                           | [Pricing](https://sevalla.com/pricing) (5 \$/m)       | $20 credit  | No                |             | Dynamic | No     |
 | [Shiper](https://shiper.app)                                             | [Builder](https://shiper.app/#pricing) (5 \$/m)       | $1          | Yes               |             | Dynamic | -      |

--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@ List of awesome hosting sorted by minimal plan price
 
 ## Sponsors
 
-Donations to project with credits on LLM/AI inferences or such bonuses from providers
+Donations to project with credits on LLM/AI inferences or such bonuses from providers.
 
-- [KiloCode](https://kilo.ai)
-- [nahcrof](https://ai.nahcrof.com)
+> There amount are not real money, it is credits within sponsor platform.
+
+| Name                                          | Status           | Amount |
+| --------------------------------------------- | ---------------- | ------ |
+| [KiloCode](https://kilo.ai)                   | Previous sponsor | $100+  |
+| [nahcrof](https://ai.nahcrof.com)             | Previous sponsor | $20+   |
+| [Qwen Ambassador](https://qwen.ai/ambassador) | Active           | $100+  |
 
 ## Status
 
@@ -358,14 +363,30 @@ List of all GPU renting/hosting providers <sup>[1](#status)</sup>
 
 List of LLM/AI inference API's <sup>[1](#status)</sup>
 
+#### Proxy services
+
+> The proxy services and providers are not guaranteed to being geninue nor legally. Please check your country and company legal terms before using these proxy services
+
+| Name                                         | Minimal plan                                  | Trial | Usage       |
+| -------------------------------------------- | --------------------------------------------- | ----- | ----------- |
+| [Cavoti][proxy-cavoti-ref]                   | [Pro][proxy-cavoti-ref] (0.50 \$/m)           | -     | $30 / month |
+| [AICodeMirror](https://www.aicodemirror.com) | [PRO](https://www.aicodemirror.com) (2 \$/m)  | -     | -           |
+| [aerolink][proxy-aerolink-ref]               | [Builder][proxy-aerolink-ref] (10 \$/m)       | -     | $140 / week |
+| [ccapi][proxy-ccapi-ref]                     | [Pricing][proxy-cavoti-ref] (<= 93% off)      | -     | -           |
+| [CCode](https://www.ccode.dev)               | [Pricing](https://www.ccode.dev) (<= 88% off) | -     | -           |
+| [Packy][proxy-packy-ref]                     | [Pricing][proxy-packy-ref] (<= 71% off)       | -     | -           |
+| [Code0][proxy-code0-ref]                     | [Pricing][proxy-code0-ref] (<= 65% off)       | -     | -           |
+| [ClaudeAPI][proxy-claudeapi-ref]             | [Pricing][proxy-claudeapi-ref] (<= 20% off)   | -     | -           |
+| [B AI](https://b.ai)                         | [Pricing](https://b.ai) (<= unknown)          | -     | -           |
+| [VisionCoder](https://coder.visioncoder.cn)  | -                                             | -     | -           |
+
 #### Subscription
 
 | Name                                                      | Minimal plan                                                  | Trial        | Usage                 |
 | --------------------------------------------------------- | ------------------------------------------------------------- | ------------ | --------------------- |
-| [Chutes](https://chutes.ai)                               | [Base](https://chutes.ai/pricing) (3 \$/m)                    | -            | 300 msg / day         |
-| **[nahcrof](https://ai.nahcrof.com)** ✅                  | [Hobby](https://ai.nahcrof.com/pricing) (5 \$/m)              | -            | 500 req / day         |
 | [Xiaomi Token Plan][xiaomi-ref]                           | [Lite][xiaomi-ref] (6 \$/m)                                   | 12% discount | 4B tokens             |
 | [NanoGPT][nano-gpt-ref]                                   | [Pro][nano-gpt-ref] (8 \$/m)                                  | -            |                       |
+| [Chutes](https://chutes.ai)                               | [Plus](https://chutes.ai/pricing) (10 \$/m)                   | -            | 300 msg / day         |
 | [MiniMax Coding][minimax-ref]                             | [Starter][minimax-ref] (10 \$/m)                              | -            | =< 100 prompts / 5-hr |
 | [OpenCode Go][opencode-ref]                               | 10 \$/m                                                       | 50% discount | $60 usage             |
 | [Featherless](https://featherless.ai)                     | [Basic](https://featherless.ai/#pricing) (10 \$/m)            | -            | up-to 15B models      |
@@ -404,7 +425,7 @@ List of LLM/AI inference API's <sup>[1](#status)</sup>
 | [Hyperbolic](https://hyperbolic.ai)           | [Pricing](https://www.hyperbolic.ai/inference)                                | $1 credit   |      |
 | [NagaAI][naga-ai-ref]                         | [Pricing](https://naga.ac/pricing)                                            | -           |      |
 | [OrcaRouter](https://orcarouter.ai)           | [Pricing](https://orcarouter.ai/pricing)                                      | $5 credit   |      |
-| **[nahcrof](https://ai.nahcrof.com)** ✅      | [Pricing](https://ai.nahcrof.com/pricing)                                     | -           |      |
+| [nahcrof](https://ai.nahcrof.com)             | [Pricing](https://ai.nahcrof.com/pricing)                                     | -           |      |
 | [Parasail](https://parasail.io)               | [Pricing](https://www.saas.parasail.io/pricing)                               | $10 credit  |      |
 | [Replicate](https://replicate.com)            | [Pricing](https://replicate.com/pricing)                                      | -           |      |
 
@@ -463,6 +484,12 @@ MIT
 [naga-ai-ref]: https://naga.ac/join?ref=374-UXE
 [nano-gpt-ref]: https://nano-gpt.com/invite/CLnWMCfV
 [opencode-ref]: https://opencode.ai/go?ref=JS7NVJ7BY1
+[proxy-aerolink-ref]: https://aerolink.lat/register?ref=ITZKKUI
+[proxy-cavoti-ref]: https://cavoti.com/register?aff=K6XBNP53XWY9
+[proxy-ccapi-ref]: https://ccapi.us/register?aff=wnpz7zef
+[proxy-claudeapi-ref]: https://console.claudeapi.com/register?aff=Lnhb
+[proxy-code0-ref]: https://console.code0.ai/register?aff=WkDx
+[proxy-packy-ref]: https://www.packyapi.com/register?aff=Ihn8
 [racknerd-ref]: https://my.racknerd.com/aff.php?aff=12402
 [rdp-monster-ref]: https://rdp.monster/?ref=144
 [requesty-ai-ref]: https://app.requesty.ai/join?ref=02b543cf

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ List of all Web services platform <sup>[1](#status)</sup>
 
 | Name                                                                 | Minimal plan                                                     | Trial       | Free                      | Open Source | Type | Lambda |
 | -------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------- | ------------------------- | ----------- | ---- | ------ |
-| [Cloudflare Workers](https://workers.cloudflare.com/product/workers) | [Pay-as-you-Go](https://workers.cloudflare.com/pricing) (5 \$/m) | No          | Yes                       |             | All  | Yes    |
+| [Cloudflare Workers](https://workers.cloudflare.com/product/workers) | [Pay-as-you-Go](https://workers.cloudflare.com/pricing) (5 \$/m) | No          | Yes  
 | [Alibaba Cloud][alibaba-cloud-ref]                                   | [Pay-as-you-Go][alibaba-cloud-ref]                               | $50 credit  | 70M tokens, $200 credit   |             | All  | Yes    |
 | [Amazon Web Services](https://aws.amazon.com)                        | [See plans](https://aws.amazon.com/pricing)                      | $200 credit | 30+ services              |             | All  | Yes    |
 | [Azure Web Services](https://azure.microsoft.com/en-us)              | [See plans](https://azure.microsoft.com/en-us/pricing)           | $200 credit | 55+ services              |             | All  | Yes    |
@@ -73,6 +73,7 @@ List of all Backend-as-a-Service platform <sup>[1](#status)</sup>
 | [DigitalOcean Platform][do-ref]                                          | [Pay-as-you-Go][do-ref] (5 \$/m)                      | $200 credit | Yes               |             | Static  | No     |
 | [Heroku](https://www.heroku.com)                                         | [Eco](https://www.heroku.com/pricing) (5 \$/m)        | No          | No                |             | Dynamic | No     |
 | [PocketHost](https://pockethost.io)                                      | [Starter](https://pockethost.io/pricing) (5 \$/m)     | No          | Yes               |             | Dynamic |        |
+| [ApexWeave](https://apexweave.com) | [Plans](https://apexweave.com/compare) (4 \$/m) | Yes | Yes | | Dynamic | No |                     |             | All  | Yes    |
 | [litegix](https://litegix.com) ⚠️                                        | [Hobby](https://litegix.com/pricing) (5 \$/m)         | No          | Yes               |             | Dynamic | -      |
 | [Sevalla](https://sevalla.com)                                           | [Pricing](https://sevalla.com/pricing) (5 \$/m)       | $20 credit  | No                |             | Dynamic | No     |
 | [Shiper](https://shiper.app)                                             | [Builder](https://shiper.app/#pricing) (5 \$/m)       | $1          | Yes               |             | Dynamic | -      |
@@ -97,6 +98,7 @@ List of all Backend-as-a-Service platform <sup>[1](#status)</sup>
 | [Dokku](https://dokku.com)                                               | Your infrastructure                                   | -           | Self-Hosted       |             | Dynamic | -      |
 | [Dokploy](https://dokploy.com)                                           | Your infrastructure                                   | -           | Self-Hosted       | Yes         | Dynamic | -      |
 | [PocketBase](https://pocketbase.io)                                      | Your infrastructure                                   | -           | Self-Hosted       |             | Dynamic | -      |
+
 
 ---
 
@@ -475,3 +477,4 @@ MIT
 [waicore-ref]: https://waicore.com/?from=3872
 [xiaomi-ref]: https://platform.xiaomimimo.com?ref=UZWW8Z
 [z-ai-ref]: https://z.ai/subscribe?ic=WYG1DQWSMW
+| [ApexWeave](https://apexweave.com) | [Plans](https://apexweave.com/compare) (4 \$/m) | Yes | Yes | | Dynamic | No |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ List of all Web services platform <sup>[1](#status)</sup>
 
 | Name                                                                 | Minimal plan                                                     | Trial       | Free                      | Open Source | Type | Lambda |
 | -------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------- | ------------------------- | ----------- | ---- | ------ |
-| [Cloudflare Workers](https://workers.cloudflare.com/product/workers) | [Pay-as-you-Go](https://workers.cloudflare.com/pricing) (5 \$/m) | No          | Yes  
+| [Cloudflare Workers](https://workers.cloudflare.com/product/workers) | [Pay-as-you-Go](https://workers.cloudflare.com/pricing) (5 \$/m) | No          | Yes                       |             | All  | Yes    |
 | [Alibaba Cloud][alibaba-cloud-ref]                                   | [Pay-as-you-Go][alibaba-cloud-ref]                               | $50 credit  | 70M tokens, $200 credit   |             | All  | Yes    |
 | [Amazon Web Services](https://aws.amazon.com)                        | [See plans](https://aws.amazon.com/pricing)                      | $200 credit | 30+ services              |             | All  | Yes    |
 | [Azure Web Services](https://azure.microsoft.com/en-us)              | [See plans](https://azure.microsoft.com/en-us/pricing)           | $200 credit | 55+ services              |             | All  | Yes    |
@@ -78,7 +78,7 @@ List of all Backend-as-a-Service platform <sup>[1](#status)</sup>
 | [DigitalOcean Platform][do-ref]                                          | [Pay-as-you-Go][do-ref] (5 \$/m)                      | $200 credit | Yes               |             | Static  | No     |
 | [Heroku](https://www.heroku.com)                                         | [Eco](https://www.heroku.com/pricing) (5 \$/m)        | No          | No                |             | Dynamic | No     |
 | [PocketHost](https://pockethost.io)                                      | [Starter](https://pockethost.io/pricing) (5 \$/m)     | No          | Yes               |             | Dynamic |        |
-| [ApexWeave](https://apexweave.com) | [Plans](https://apexweave.com/compare) (4 \$/m) | Yes | Yes | | Dynamic | No |                     |             | All  | Yes    |
+| [ApexWeave](https://apexweave.com)                                       | [Plans](https://apexweave.com/compare) (4 \$/m)       | Yes         | Yes               |             | Dynamic | No     |
 | [litegix](https://litegix.com) ⚠️                                        | [Hobby](https://litegix.com/pricing) (5 \$/m)         | No          | Yes               |             | Dynamic | -      |
 | [Sevalla](https://sevalla.com)                                           | [Pricing](https://sevalla.com/pricing) (5 \$/m)       | $20 credit  | No                |             | Dynamic | No     |
 | [Shiper](https://shiper.app)                                             | [Builder](https://shiper.app/#pricing) (5 \$/m)       | $1          | Yes               |             | Dynamic | -      |
@@ -103,7 +103,6 @@ List of all Backend-as-a-Service platform <sup>[1](#status)</sup>
 | [Dokku](https://dokku.com)                                               | Your infrastructure                                   | -           | Self-Hosted       |             | Dynamic | -      |
 | [Dokploy](https://dokploy.com)                                           | Your infrastructure                                   | -           | Self-Hosted       | Yes         | Dynamic | -      |
 | [PocketBase](https://pocketbase.io)                                      | Your infrastructure                                   | -           | Self-Hosted       |             | Dynamic | -      |
-
 
 ---
 
@@ -504,4 +503,3 @@ MIT
 [waicore-ref]: https://waicore.com/?from=3872
 [xiaomi-ref]: https://platform.xiaomimimo.com?ref=UZWW8Z
 [z-ai-ref]: https://z.ai/subscribe?ic=WYG1DQWSMW
-| [ApexWeave](https://apexweave.com) | [Plans](https://apexweave.com/compare) (4 \$/m) | Yes | Yes | | Dynamic | No |


### PR DESCRIPTION
Adds ApexWeave (Heroku-style PaaS, plans from $4/mo, 14-day free trial) to the BaaS table, sorted by price alongside Heroku and PocketHost.