### PR TITLE
docs(resources): add `hostingshortlist.com` price index

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ List of LLM/AI inference API's <sup>[1](#status)</sup>
 - <https://gist.github.com/bmaupin/0ce79806467804fdbbf8761970511b8c>
 - <https://gist.github.com/bmaupin/d2d243218863320b01b0c1e1ca0cf5f3>
 - <https://github.com/anaibol/awesome-serverless#hosting-and-code-execution-in-the-cloud>
+- <https://hostingshortlist.com/data/price-index>
 - <https://www.flightcontrol.dev>
 - <https://www.vpsbenchmarks.com>
 


### PR DESCRIPTION
Adds one resource link under **Resources**.

**What it is:** an independent, monthly-updated price index for web hosting. It tracks the **renewal price** per provider, not just the advertised entry plan, and publishes the series as open data (CC BY 4.0) with a machine-readable JSON feed.

**Why it fits:** this list is sorted by minimal plan price and, per the rules, excludes temporary and yearly discounts. The renewal price is exactly the number that lives outside that scope, so this is complementary reference data rather than an overlapping provider entry. It sits next to peers like `vpsbenchmarks.com` as an independent data source.

**Verification:**

- URL: <https://hostingshortlist.com/data/price-index> (no trailing slash, live, HTTP 200)
- License: CC BY 4.0, machine-readable JSON at `/data/price-index.json`
- Placed alphabetically in the Resources list; `prettier --write README.md` run, single-line diff.

**Disclosure:** I maintain the site. Adding it here only because the renewal-price angle is genuinely missing from the list; happy to adjust the wording, move it, or close if it is not a fit.
