### PR TITLE
docs(static): Add Layero to Static

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ List of all static site hosting platform <sup>[1](#status)</sup>
 | [Qoddi](https://qoddi.com)                                       | [XS](https://qoddi.com/pricing) (6 \$/m)                 | No          | 3 apps    |                   | Static | No     |
 | [Stacktree](https://stacktr.ee)                                  | [Pro](https://stacktr.ee/pricing) (8 \$/m)               | No          | Yes       |                   | Static | No     |
 | [Netlify](https://www.netlify.com)                               | [Personal](https://www.netlify.com/pricing) (9 \$/m)     | No          | Yes       | Yes               | Static | Yes    |
+| [Layero](https://layero.ru)                                      | [Pro](https://layero.ru/pricing) (12.69 \$/m)            | No          | Yes       |                   | Static | No     |
 | [Sherpa](https://www.sherpa.sh)                                  | [Hobby](https://www.sherpa.sh/pricing) (13.99 \$/m)      | No          | Yes       |                   | Static | Yes    |
 | [dAppling Network](https://dappling.network)                     | [Grow](https://www.dappling.network) (20 \$/user/m)      | No          | Yes       |                   | Static | No     |
 | [Vercel](https://vercel.com)                                     | [Pro](https://vercel.com/pricing) (20 \$/m)              | No          | Yes       | Increase resource | Static | Yes    |


### PR DESCRIPTION
Adds [Layero](https://layero.ru) to the **Static** section.

Disclosure: I work on Layero. Data below is from the provider's own public pricing page, current today.

| Field | Value | Source |
|---|---|---|
| Minimal plan | Pro, 990 ₽/m → **12.69 $/m** | <https://layero.ru/pricing> |
| Trial | No | no trial offered |
| Free | Yes — 5 projects, 100 webhook builds/m, platform subdomain | <https://docs.layero.ru/billing/plans> |
| Open Source | *(blank)* | no OSS-specific discount |
| Type | Static | static sites and SPAs |
| Lambda | No | no standalone serverless functions |

Currency conversion per `AGENTS.md`: the provider prices in RUB, so the figure is converted to USD at the Central Bank of Russia rate for 2026-07-25, 1 $ = 78.03 ₽ → 990 / 78.03 = 12.69. Sorted between Netlify (9 $/m) and Sherpa (13.99 $/m).

Notes:
- Monthly price, not a discounted or yearly rate.
- Free plan exists, so the Minimal plan column shows the lowest paid tier rather than $0, per the rules.
- Extra team seats are 490 ₽/m each and are not part of the base plan, so they are not reflected in the table.
- URLs have no trailing slash; `npx prettier -c README.md --write` was run and produced no further changes.
- `grep -i layero` on the current README returns nothing, so this is not a duplicate.